### PR TITLE
fix: Don't totally fail if cannot load MongoDB version.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3061,12 +3061,12 @@
       "dev": true
     },
     "bunyan": {
-      "version": "1.8.12",
-      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.12.tgz",
-      "integrity": "sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=",
+      "version": "1.8.14",
+      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.14.tgz",
+      "integrity": "sha512-LlahJUxXzZLuw/hetUQJmRgZ1LF6+cr5TPpRj6jf327AsiIq2jhYEH4oqUUkVKTor+9w2BT3oxVwhzE5lw9tcg==",
       "requires": {
         "dtrace-provider": "~0.8",
-        "moment": "^2.10.6",
+        "moment": "^2.19.3",
         "mv": "~2",
         "safe-json-stringify": "~1"
       }
@@ -7944,9 +7944,9 @@
       "dev": true
     },
     "moment": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.26.0.tgz",
-      "integrity": "sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw=="
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "mongo-object": {
       "version": "0.1.4",
@@ -7978,9 +7978,9 @@
       }
     },
     "nan": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
       "optional": true
     },
     "nanomatch": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "sideEffects": false,
   "dependencies": {
     "@reactioncommerce/api-utils": "^1.14.2",
+    "@reactioncommerce/logger": "^1.1.3",
     "@reactioncommerce/reaction-error": "^1.0.1"
   },
   "devDependencies": {

--- a/src/queries/systemInformation.js
+++ b/src/queries/systemInformation.js
@@ -1,3 +1,5 @@
+import Logger from "@reactioncommerce/logger";
+
 /**
  * @name queries.systemInformation
  * @method
@@ -12,12 +14,20 @@ export default async function systemInformation(context, shopId) {
 
   await context.validatePermissions(`reaction:legacy:shops:${shopId}`, "read", { shopId });
 
-  const mongoAdmin = await db.admin();
-  const mongoInfo = await mongoAdmin.serverStatus();
+  let mongoVersion = "";
+
+  try {
+    const mongoAdmin = await db.admin();
+    const mongoInfo = await mongoAdmin.serverStatus();
+    mongoVersion = mongoInfo.version;
+  } catch (error) {
+    Logger.error(error);
+  }
+
   const plugins = Object.values(context.app.registeredPlugins).filter((plugin) => plugin.version);
   return {
     apiVersion: context.appVersion,
-    mongoVersion: { version: mongoInfo.version },
+    mongoVersion: { version: mongoVersion },
     plugins: plugins.map(({ name, version }) => ({ name, version }))
   };
 }


### PR DESCRIPTION
The MongoDB `serverStatus` call requires special permissions, which are either not available, or not set by default in hosted environments, or even undesirable as it give read access to the `admin` database. In this instance, the entire systemInformation call would fail as a GraphQL error.

This PR captures (and logs) the error, but will resolve the version to an empty string instead.  This means the systemInformation call will succeed and still emit the plugin/Reaction version information.

No breaking changes, compatible with existing version.